### PR TITLE
Fix assertion error with net firmware argument

### DIFF
--- a/show
+++ b/show
@@ -143,7 +143,7 @@ def main():
             ('mac', 'MAC', 'net'),
             ('show_type', 'Type', 'net'),
             ('driver', 'Driver', 'net'),
-            ('firmware', 'Firmware', 'net'))
+            ('firmware_version', 'Firmware', 'net'))
 
         header = ['Dev']
 
@@ -153,7 +153,7 @@ def main():
                         if option[2] == args.devicetype:
                             header.append(option[1])
 
-        #print "Header " + str(header)
+        # print("Header " + str(header))
 
         return header
 


### PR DESCRIPTION
Fix following assertion error when using `net` and `-F` arg.
```
./show net -lF
Traceback (most recent call last):
  File "/home/sen/sources/showtools/show", line 778, in <module>
    main()
  File "/home/sen/sources/showtools/show", line 169, in main
    display_table(table_header, table_data, args)
  File "/home/sen/sources/showtools/show", line 719, in display_table
    assert header_length == data_length, "Column count mismatch! %r/%r" % (header_length, data_length)
```