### PR TITLE
Fix TypeError with transparent argument

### DIFF
--- a/show
+++ b/show
@@ -730,6 +730,7 @@ def display_table(table_header, table_data, args):
     for col in col_widths:
         if args.transparent:
             form = "  %-" + str(col) + "s "
+            format += form
         else:
             form = "| %-" + str(col) + "s "
             format += form


### PR DESCRIPTION
Fix following Type error when using `-E` arg.
```
./show disk -E
        
Traceback (most recent call last):
  File "/home/sen/sources/showtools/./show", line 775, in <module>
    main()
  File "/home/sen/sources/showtools/./show", line 169, in main
    display_table(table_header, table_data, args)
  File "/home/sen/sources/showtools/./show", line 744, in display_table
    print(format % tuple(table_header))
TypeError: not all arguments converted during string formatting
```